### PR TITLE
Fix clamp imports

### DIFF
--- a/NavigationExperimentalComponents/NavigationCardStackPanResponder.js
+++ b/NavigationExperimentalComponents/NavigationCardStackPanResponder.js
@@ -15,7 +15,7 @@ const { Animated, I18nManager } = require('react-native');
 
 const NavigationAbstractPanResponder = require('../NavigationAbstractPanResponder');
 
-const clamp = require('clamp');
+const clamp = require('react-native/Libraries/Utilities/clamp');
 
 import type {
   NavigationPanPanHandlers,

--- a/NavigationExperimentalComponents/NavigationPagerPanResponder.js
+++ b/NavigationExperimentalComponents/NavigationPagerPanResponder.js
@@ -16,7 +16,7 @@ const { Animated, I18nManager } = require('react-native');
 const NavigationAbstractPanResponder = require('../NavigationAbstractPanResponder');
 const NavigationCardStackPanResponder = require('./NavigationCardStackPanResponder');
 
-const clamp = require('clamp');
+const clamp = require('react-native/Libraries/Utilities/clamp');
 
 import type {
   NavigationPanPanHandlers,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ NavigationExperimental from RN 0.43.3. Useful when you still depend on it in RN 
 
 or
 
-`yard add navigation-experimental-fork`
+`yarn add navigation-experimental-fork`
 
 
 ### Use


### PR DESCRIPTION
On `0.45-rc.0` this module breaks on the `clamp` imports, so I made them deep requires instead of relying on `@providesModule` which I believe is deprecated. 