### PR TITLE
Fix crash on Android on RN versions >= 0.50 and React 16 stable

### DIFF
--- a/NavigationExperimentalComponents/NavigationCardStack.js
+++ b/NavigationExperimentalComponents/NavigationCardStack.js
@@ -40,7 +40,7 @@ const NavigationPropTypes = require('../NavigationPropTypes');
 const NavigationTransitioner = require('../NavigationTransitioner');
 import React, { Component } from 'react';
 
-const { Animated, StyleSheet, View } = require('react-native');
+const { Animated, StyleSheet, View, ViewPropTypes } = require('react-native');
 
 const PropTypes = require('prop-types');;
 const { Directions } = NavigationCardStackPanResponder;
@@ -200,12 +200,12 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     /**
      * Custom style applied to the cards stack.
      */
-    style: View.propTypes.style,
+    style: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
 
     /**
      * Custom style applied to the scenes stack.
      */
-    scenesStyle: View.propTypes.style,
+    scenesStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
   };
 
   static defaultProps: DefaultProps = {

--- a/NavigationExperimentalComponents/NavigationHeader.js
+++ b/NavigationExperimentalComponents/NavigationHeader.js
@@ -40,7 +40,7 @@ import React, { Component } from 'react';
 
 // const TVEventHandler = require('TVEventHandler');
 
-import { Animated, Platform, StyleSheet, View, TVEventHandler } from 'react-native';
+import { Animated, Platform, StyleSheet, View, TVEventHandler, ViewPropTypes } from 'react-native';
 
 import type {
   NavigationSceneRendererProps,
@@ -105,7 +105,7 @@ class NavigationHeader extends React.PureComponent<DefaultProps, Props, any> {
     renderLeftComponent: PropTypes.func,
     renderRightComponent: PropTypes.func,
     renderTitleComponent: PropTypes.func,
-    style: View.propTypes.style,
+    style: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
     statusBarHeight: PropTypes.number,
     viewProps: PropTypes.shape(View.propTypes),
   };

--- a/NavigationExperimentalComponents/NavigationHeaderTitle.js
+++ b/NavigationExperimentalComponents/NavigationHeaderTitle.js
@@ -41,6 +41,7 @@ const {
   StyleSheet,
   View,
   Text,
+  ViewPropTypes
 } = ReactNative;
 
 type Props = {
@@ -75,7 +76,7 @@ const styles = StyleSheet.create({
 
 NavigationHeaderTitle.propTypes = {
   children: PropTypes.node.isRequired,
-  style: View.propTypes.style,
+  style: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
   textStyle: Text.propTypes.style
 };
 


### PR DESCRIPTION
We are experiencing crash on App startup on Android on production builds. Looks like we are dealing with known issue: https://github.com/facebook/react-native/issues/16567

I've modified NavigationCardStack, NavigationHeader and NavigationHeaderTitle to use ReactNative's ViewPropTypes if available

